### PR TITLE
feat: Allow anonymous template creation

### DIFF
--- a/docs/02-features.md
+++ b/docs/02-features.md
@@ -542,13 +542,13 @@
 
 ### 5.6 Template Creation Form
 
-- [ ] Page at `/templates/new` (no auth required)
+- [x] Page at `/templates/new` (no auth required)
 - [x] Title input (required, 5-100 chars)
 - [x] Body textarea (required, 50-10000 chars)
 - [x] Issue tags multi-select
 - [x] Turnstile widget (when configured)
 - [x] Submit button
-- [ ] Anonymous templates treated as NEW_USER for moderation
+- [x] Anonymous templates treated as NEW_USER for moderation
 
 **Tests:**
 
@@ -559,13 +559,13 @@
 ### 5.7 Template Creation Endpoint
 
 - [x] POST `/api/templates`
-- [ ] Allows anonymous users (creates template without userId)
+- [x] Allows anonymous users (creates template without userId)
 - [x] Validates Turnstile token (when configured)
 - [x] Validates input (length, format, spam patterns)
 - [x] Generates unique slug
-- [ ] Runs content moderation (Phase 6)
+- [x] Runs content moderation (Phase 6)
 - [x] Saves with pending moderation_status
-- [ ] Anonymous templates use NEW_USER trust level for moderation
+- [x] Anonymous templates use NEW_USER trust level for moderation
 - [x] Returns created template
 
 **Tests:**
@@ -590,7 +590,7 @@
 ### 5.9 My Templates Page
 
 - [x] Page at `/templates/mine` (requires auth)
-- [ ] Auth only required for viewing own templates, not creating
+- [x] Auth only required for viewing own templates, not creating
 - [x] Lists user's own templates
 - [x] Shows moderation status for each
 - [x] Edit and delete actions

--- a/src/pages/api/templates/index.ts
+++ b/src/pages/api/templates/index.ts
@@ -7,7 +7,6 @@ import { getRequiredEnv, getOptionalEnv } from "@/lib/env";
 import {
   jsonResponse,
   badRequest,
-  unauthorized,
   forbidden,
   serverError,
   validationError,
@@ -15,15 +14,12 @@ import {
 import { parseJsonBody, templateBodySchema } from "@/lib/request-body";
 import { moderateTemplate } from "@/lib/moderation/moderate-template";
 import { incrementApprovedTemplatesCount } from "@/lib/user-trust";
+import { TRUST_LEVELS } from "@/lib/trust-level";
 
 export const prerender = false;
 
 export const POST: APIRoute = async ({ request, locals }) => {
   const user = locals.user;
-
-  if (!user) {
-    return unauthorized();
-  }
 
   const parseResult = await parseJsonBody(request, templateBodySchema);
   if (!parseResult.success) {
@@ -74,13 +70,15 @@ export const POST: APIRoute = async ({ request, locals }) => {
   try {
     const db = createDb(getRequiredEnv(locals, "DATABASE_URL"));
 
-    const [userRecord] = await db
-      .select({ trustLevel: users.trustLevel })
-      .from(users)
-      .where(eq(users.id, user.id))
-      .limit(1);
-
-    const trustLevel = userRecord?.trustLevel ?? 0;
+    let trustLevel: number = TRUST_LEVELS.NEW_USER;
+    if (user) {
+      const [userRecord] = await db
+        .select({ trustLevel: users.trustLevel })
+        .from(users)
+        .where(eq(users.id, user.id))
+        .limit(1);
+      trustLevel = userRecord?.trustLevel ?? TRUST_LEVELS.NEW_USER;
+    }
 
     const openaiKey = getOptionalEnv(locals, "OPENAI_API_KEY");
     const contentToModerate = `${title}\n\n${templateBody}`;
@@ -95,7 +93,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
         title: title.trim(),
         body: templateBody.trim(),
         issueTags: issueTags?.filter((t: string) => t.trim()) ?? [],
-        userId: user.id,
+        userId: user?.id ?? null,
         isPublic: true,
         moderationStatus: moderation.status,
         moderationScores: moderation.scores,
@@ -110,7 +108,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
         createdAt: templates.createdAt,
       });
 
-    if (moderation.status === "approved") {
+    if (moderation.status === "approved" && user) {
       await incrementApprovedTemplatesCount(db, user.id);
     }
 

--- a/src/pages/templates/new.astro
+++ b/src/pages/templates/new.astro
@@ -8,10 +8,6 @@ import { TemplateCreateClient } from "@/components/TemplateCreateClient";
 
 const user = Astro.locals.user;
 
-if (!user) {
-  return Astro.redirect("/templates?login=required");
-}
-
 const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY || "";
 ---
 

--- a/tests/api/templates/create.test.ts
+++ b/tests/api/templates/create.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { POST } from "@/pages/api/templates/index";
 
 describe("Template Creation Endpoint", () => {
-  it("returns 401 when not authenticated", async () => {
+  it("accepts anonymous users for template creation", async () => {
     const mockRequest = new Request("http://localhost/api/templates", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -22,9 +22,7 @@ describe("Template Creation Endpoint", () => {
       locals: mockLocals,
     } as never);
 
-    expect(response.status).toBe(401);
-    const data = await response.json();
-    expect(data.error).toBe("Authentication required");
+    expect(response.status).not.toBe(401);
   });
 
   it("returns 400 for missing title", async () => {


### PR DESCRIPTION
## Summary
- Remove auth requirement from `/templates/new` page
- Allow `POST /api/templates` without authentication
- Anonymous templates use NEW_USER trust level for moderation
- Anonymous templates have null userId

## Rationale
Users requested that unauthenticated users should be able to create templates. Auth is only required for:
- Viewing "My Templates" page
- Marking templates as private
- Editing/deleting templates

Anonymous templates go through the same moderation pipeline as authenticated users at NEW_USER trust level.

## Test plan
- [ ] Anonymous user can access /templates/new
- [ ] Anonymous user can submit a template
- [ ] Template is created with null userId
- [ ] Template goes through moderation as NEW_USER

🤖 Generated with [Claude Code](https://claude.com/claude-code)