### PR TITLE
feat: Add moderation to template PUT/update endpoint

### DIFF
--- a/src/pages/api/templates/[slug].ts
+++ b/src/pages/api/templates/[slug].ts
@@ -1,9 +1,9 @@
 import type { APIRoute } from "astro";
 import { createDb } from "@/db/client";
-import { templates, type Template } from "@/db/schema";
+import { templates, users, type Template } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { validateTemplate } from "@/lib/template-validation";
-import { getRequiredEnv } from "@/lib/env";
+import { getRequiredEnv, getOptionalEnv } from "@/lib/env";
 import {
   jsonResponse,
   badRequest,
@@ -14,6 +14,8 @@ import {
   validationError,
 } from "@/lib/api-response";
 import { parseJsonBody, templateBodySchema } from "@/lib/request-body";
+import { moderateTemplate } from "@/lib/moderation/moderate-template";
+import { TRUST_LEVELS } from "@/lib/trust-level";
 
 export const prerender = false;
 
@@ -130,13 +132,25 @@ export const PUT: APIRoute = async ({ params, request, locals }) => {
       return forbidden();
     }
 
+    const [userRecord] = await db
+      .select({ trustLevel: users.trustLevel })
+      .from(users)
+      .where(eq(users.id, user.id))
+      .limit(1);
+    const trustLevel = userRecord?.trustLevel ?? TRUST_LEVELS.NEW_USER;
+
+    const openaiKey = getOptionalEnv(locals, "OPENAI_API_KEY");
+    const contentToModerate = `${title}\n\n${templateBody}`;
+    const moderation = await moderateTemplate(contentToModerate, openaiKey, trustLevel);
+
     const [updatedTemplate] = await db
       .update(templates)
       .set({
         title: title.trim(),
         body: templateBody.trim(),
         issueTags: issueTags?.filter((t: string) => t.trim()) ?? [],
-        moderationStatus: "pending",
+        moderationStatus: moderation.status,
+        moderationScores: moderation.scores,
         updatedAt: new Date(),
       })
       .where(eq(templates.id, existingTemplate.id))


### PR DESCRIPTION
## Summary
- Run OpenAI moderation when templates are updated (same logic as creation)
- Fetch user's trust level to determine auto-approval threshold
- Store moderation status and scores on updated templates
- Templates that fail moderation become pending, requiring re-approval

## Changes
- Updated `src/pages/api/templates/[slug].ts` to include moderation on PUT

## Security
- Moderation prevents previously-approved templates from bypassing checks on edit
- Trust level is fetched fresh from database (cannot be spoofed)
- Ownership is verified before moderation is run

## Test plan
- [x] TypeScript compiles without errors
- [x] All existing tests pass
- [x] Lint passes
- [ ] Manual: Edit a template as NEW_USER → should become pending
- [ ] Manual: Edit a template as TRUSTED user with clean content → should auto-approve

🤖 Generated with [Claude Code](https://claude.com/claude-code)