### PR TITLE
feat: Add updatedAt to public template fields

### DIFF
--- a/src/pages/api/templates/[slug].ts
+++ b/src/pages/api/templates/[slug].ts
@@ -30,6 +30,7 @@ type PublicTemplateFields = Pick<
   | "useCount"
   | "forkedFrom"
   | "createdAt"
+  | "updatedAt"
 >;
 
 function filterPublicFields(template: Template): PublicTemplateFields {
@@ -43,6 +44,7 @@ function filterPublicFields(template: Template): PublicTemplateFields {
     useCount: template.useCount,
     forkedFrom: template.forkedFrom,
     createdAt: template.createdAt,
+    updatedAt: template.updatedAt,
   };
 }
 


### PR DESCRIPTION
## Summary
Include `updatedAt` timestamp in the public template response so clients can display when a template was last modified.

## Changes
- Added `updatedAt` to `PublicTemplateFields` type
- Added `updatedAt` to `filterPublicFields` function

🤖 Generated with [Claude Code](https://claude.com/claude-code)