### PR TITLE
refactor: Add Zod validation to auth OTP endpoints

### DIFF
--- a/src/lib/request-body.ts
+++ b/src/lib/request-body.ts
@@ -39,3 +39,16 @@ export const flagBodySchema = z.object({
 });
 
 export type FlagBody = z.infer<typeof flagBodySchema>;
+
+export const requestOtpBodySchema = z.object({
+  email: z.string().email(),
+});
+
+export type RequestOtpBody = z.infer<typeof requestOtpBodySchema>;
+
+export const verifyOtpBodySchema = z.object({
+  email: z.string().email(),
+  otp: z.string().min(1),
+});
+
+export type VerifyOtpBody = z.infer<typeof verifyOtpBodySchema>;

--- a/src/pages/api/auth/request-otp.ts
+++ b/src/pages/api/auth/request-otp.ts
@@ -2,22 +2,19 @@ import type { APIRoute } from "astro";
 import { and, eq, gte } from "drizzle-orm";
 import { createDb } from "@/db/client";
 import { emailOtps } from "@/db/schema";
+import { badRequest, serverError, jsonResponse } from "@/lib/api-response";
 import { hashEmail } from "@/lib/auth/hash-email";
 import { generateOTP } from "@/lib/auth/otp";
 import { sendEmail } from "@/lib/email";
 import { createOtpEmail } from "@/lib/email/templates/otp";
 import { getRequiredEnv } from "@/lib/env";
+import { parseJsonBody, requestOtpBodySchema } from "@/lib/request-body";
 
 export const prerender = false;
 
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const OTP_EXPIRY_MINUTES = 10;
 const RATE_LIMIT_MAX_REQUESTS = 5;
 const RATE_LIMIT_WINDOW_HOURS = 1;
-
-export function validateEmail(email: string): boolean {
-  return EMAIL_REGEX.test(email);
-}
 
 type EmailSender = (
   message: Parameters<typeof sendEmail>[0],
@@ -30,10 +27,6 @@ export async function requestOTP(
   db?: ReturnType<typeof createDb>,
   emailSender: EmailSender = sendEmail
 ): Promise<{ success: boolean; error?: string }> {
-  if (!validateEmail(email)) {
-    return { success: false, error: "Invalid email format" };
-  }
-
   const emailHash = hashEmail(email);
 
   if (db) {
@@ -74,36 +67,24 @@ export async function requestOTP(
 }
 
 export const POST: APIRoute = async ({ request, locals }) => {
+  const parseResult = await parseJsonBody(request, requestOtpBodySchema);
+  if (!parseResult.success) {
+    return badRequest(parseResult.error);
+  }
+
+  const { email } = parseResult.data;
+
   try {
-    const body = await request.json();
-    const { email } = body;
-
-    if (!email || typeof email !== "string") {
-      return new Response(JSON.stringify({ success: false, error: "Email required" }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-
     const db = createDb(getRequiredEnv(locals, "DATABASE_URL"));
     const result = await requestOTP(email, locals, db);
 
     if (!result.success) {
-      return new Response(JSON.stringify(result), {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      });
+      return badRequest(result.error ?? "Request failed");
     }
 
-    return new Response(JSON.stringify({ success: true }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    });
+    return jsonResponse({ success: true });
   } catch (error) {
     console.error("OTP request error:", error);
-    return new Response(JSON.stringify({ success: false, error: "Internal error" }), {
-      status: 500,
-      headers: { "Content-Type": "application/json" },
-    });
+    return serverError("Internal error");
   }
 };

--- a/src/pages/api/auth/verify-otp.ts
+++ b/src/pages/api/auth/verify-otp.ts
@@ -1,11 +1,13 @@
 import type { APIRoute } from "astro";
-import { eq, and, isNull, gt } from "drizzle-orm";
-import { createDb, type Database } from "../../../db/client";
-import { emailOtps, users, sessions } from "../../../db/schema";
-import { hashEmail } from "../../../lib/auth/hash-email";
-import { hashOTP } from "../../../lib/auth/otp";
 import { randomUUID } from "crypto";
+import { eq, and, isNull, gt } from "drizzle-orm";
+import { createDb, type Database } from "@/db/client";
+import { emailOtps, users, sessions } from "@/db/schema";
+import { badRequest, unauthorized, serverError, jsonResponse } from "@/lib/api-response";
+import { hashEmail } from "@/lib/auth/hash-email";
+import { hashOTP } from "@/lib/auth/otp";
 import { getRequiredEnv } from "@/lib/env";
+import { parseJsonBody, verifyOtpBodySchema } from "@/lib/request-body";
 
 export const prerender = false;
 
@@ -23,7 +25,6 @@ export async function verifyOTPRequest(
   const emailHash = hashEmail(email);
   const otpHash = hashOTP(otp);
 
-  // Find valid OTP record by both email hash and OTP hash
   const otpRecords = await db
     .select()
     .from(emailOtps)
@@ -42,10 +43,8 @@ export async function verifyOTPRequest(
 
   const matchingRecord = otpRecords[0];
 
-  // Mark OTP as used
   await db.update(emailOtps).set({ usedAt: new Date() }).where(eq(emailOtps.id, matchingRecord.id));
 
-  // Get or create user
   const userRecords = await db.select().from(users).where(eq(users.emailHash, emailHash));
 
   let userId: string;
@@ -57,7 +56,6 @@ export async function verifyOTPRequest(
     userId = userRecords[0].id;
   }
 
-  // Create session (30 days)
   const sessionId = randomUUID();
   const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
 
@@ -71,45 +69,32 @@ export async function verifyOTPRequest(
 }
 
 export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const parseResult = await parseJsonBody(request, verifyOtpBodySchema);
+  if (!parseResult.success) {
+    return badRequest(parseResult.error);
+  }
+
+  const { email, otp } = parseResult.data;
+
   try {
-    const body = await request.json();
-    const { email, otp } = body;
-
-    if (!email || typeof email !== "string" || !otp || typeof otp !== "string") {
-      return new Response(JSON.stringify({ success: false, error: "Email and OTP required" }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-
     const db = createDb(getRequiredEnv(locals, "DATABASE_URL"));
     const result = await verifyOTPRequest(email, otp, db);
 
     if (!result.success || !result.sessionId) {
-      return new Response(JSON.stringify(result), {
-        status: 401,
-        headers: { "Content-Type": "application/json" },
-      });
+      return unauthorized(result.error ?? "Invalid or expired OTP");
     }
 
-    // Set session cookie
     cookies.set("session", result.sessionId, {
       httpOnly: true,
       secure: !import.meta.env.DEV,
       sameSite: "strict",
       path: "/",
-      maxAge: 30 * 24 * 60 * 60, // 30 days
+      maxAge: 30 * 24 * 60 * 60,
     });
 
-    return new Response(JSON.stringify({ success: true }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    });
+    return jsonResponse({ success: true });
   } catch (error) {
     console.error("OTP verification error:", error);
-    return new Response(JSON.stringify({ success: false, error: "Internal error" }), {
-      status: 500,
-      headers: { "Content-Type": "application/json" },
-    });
+    return serverError("Internal error");
   }
 };

--- a/tests/api/auth/request-otp.test.ts
+++ b/tests/api/auth/request-otp.test.ts
@@ -15,7 +15,8 @@ vi.mock("@/lib/auth/send-otp-email", () => ({
   sendOTPEmail: vi.fn().mockResolvedValue(true),
 }));
 
-import { requestOTP, validateEmail } from "@/pages/api/auth/request-otp";
+import { requestOTP } from "@/pages/api/auth/request-otp";
+import { requestOtpBodySchema } from "@/lib/request-body";
 
 const mockLocals = {
   user: null,
@@ -34,18 +35,18 @@ describe("OTP Request Endpoint", () => {
     vi.clearAllMocks();
   });
 
-  describe("validateEmail", () => {
+  describe("requestOtpBodySchema", () => {
     it("accepts valid email format", () => {
-      expect(validateEmail("test@example.com")).toBe(true);
-      expect(validateEmail("user.name@domain.org")).toBe(true);
-      expect(validateEmail("user+tag@example.com")).toBe(true);
+      expect(requestOtpBodySchema.safeParse({ email: "test@example.com" }).success).toBe(true);
+      expect(requestOtpBodySchema.safeParse({ email: "user.name@domain.org" }).success).toBe(true);
+      expect(requestOtpBodySchema.safeParse({ email: "user+tag@example.com" }).success).toBe(true);
     });
 
     it("rejects invalid email format", () => {
-      expect(validateEmail("notanemail")).toBe(false);
-      expect(validateEmail("@nodomain.com")).toBe(false);
-      expect(validateEmail("missing@")).toBe(false);
-      expect(validateEmail("")).toBe(false);
+      expect(requestOtpBodySchema.safeParse({ email: "notanemail" }).success).toBe(false);
+      expect(requestOtpBodySchema.safeParse({ email: "@nodomain.com" }).success).toBe(false);
+      expect(requestOtpBodySchema.safeParse({ email: "missing@" }).success).toBe(false);
+      expect(requestOtpBodySchema.safeParse({ email: "" }).success).toBe(false);
     });
   });
 
@@ -53,12 +54,6 @@ describe("OTP Request Endpoint", () => {
     it("returns success for valid email", async () => {
       const result = await requestOTP("test@example.com", mockLocals);
       expect(result.success).toBe(true);
-    });
-
-    it("returns error for invalid email format", async () => {
-      const result = await requestOTP("invalid-email", mockLocals);
-      expect(result.success).toBe(false);
-      expect(result.error).toBe("Invalid email format");
     });
 
     it("returns generic success even for non-existent email (no info leakage)", async () => {


### PR DESCRIPTION
## Summary
- Add `requestOtpBodySchema` and `verifyOtpBodySchema` Zod schemas to `request-body.ts`
- Update `request-otp.ts` and `verify-otp.ts` to use `parseJsonBody` with Zod validation
- Remove redundant manual email validation in favor of Zod's built-in email validation
- Update tests to validate the Zod schema directly

## Test plan
- [x] All 370 existing tests pass
- [x] TypeScript compilation passes
- [x] Linting passes
- [x] Code reviewed for security and simplification

🤖 Generated with [Claude Code](https://claude.com/claude-code)