### PR TITLE
feat: Add tag suggestions system (Phase 7.6)

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -162,6 +162,23 @@ export const userTemplates = pgTable(
   (table) => [primaryKey({ columns: [table.userId, table.templateId] })]
 );
 
+export const tagSuggestions = pgTable(
+  "tag_suggestions",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    name: varchar("name", { length: 50 }).notNull(),
+    suggestedBy: uuid("suggested_by").references(() => users.id, { onDelete: "set null" }),
+    status: varchar("status", { length: 20 }).notNull().default("pending"),
+    approvedBy: uuid("approved_by").references(() => users.id, { onDelete: "set null" }),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [
+    index("tag_suggestions_name_idx").on(table.name),
+    index("tag_suggestions_status_idx").on(table.status),
+  ]
+);
+
 export type Legislator = typeof legislators.$inferSelect;
 export type NewLegislator = typeof legislators.$inferInsert;
 export type ZipDistrict = typeof zipDistricts.$inferSelect;
@@ -180,3 +197,5 @@ export type ModerationLogEntry = typeof moderationLog.$inferSelect;
 export type NewModerationLogEntry = typeof moderationLog.$inferInsert;
 export type UserTemplate = typeof userTemplates.$inferSelect;
 export type NewUserTemplate = typeof userTemplates.$inferInsert;
+export type TagSuggestion = typeof tagSuggestions.$inferSelect;
+export type NewTagSuggestion = typeof tagSuggestions.$inferInsert;

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -27,6 +27,10 @@ export function notFound(error = "Not found"): Response {
   return errorResponse(error, 404);
 }
 
+export function conflict(error: string): Response {
+  return errorResponse(error, 409);
+}
+
 export function serverError(error = "Internal server error"): Response {
   return errorResponse(error, 500);
 }

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -5,7 +5,7 @@ import Layout from "@/layouts/Layout.astro";
 import Header from "@/components/Header.astro";
 import Footer from "@/components/Footer.astro";
 import { createDb } from "@/db/client";
-import { templates, users } from "@/db/schema";
+import { templates, users, tagSuggestions } from "@/db/schema";
 import { eq, count } from "drizzle-orm";
 import { getRequiredEnv } from "@/lib/env";
 import { isAdmin } from "@/lib/admin";
@@ -25,6 +25,7 @@ let stats = {
   flaggedTemplates: 0,
   totalUsers: 0,
   totalTemplates: 0,
+  pendingTags: 0,
 };
 
 try {
@@ -44,11 +45,17 @@ try {
 
   const [templatesResult] = await db.select({ count: count() }).from(templates);
 
+  const [pendingTagsResult] = await db
+    .select({ count: count() })
+    .from(tagSuggestions)
+    .where(eq(tagSuggestions.status, "pending"));
+
   stats = {
     pendingReviews: pendingResult?.count ?? 0,
     flaggedTemplates: flaggedResult?.count ?? 0,
     totalUsers: usersResult?.count ?? 0,
     totalTemplates: templatesResult?.count ?? 0,
+    pendingTags: pendingTagsResult?.count ?? 0,
   };
 } catch (error) {
   console.error("Failed to load admin stats:", error);
@@ -148,6 +155,36 @@ try {
             <div>
               <div class="font-semibold text-[var(--color-civic-navy)]">User Management</div>
               <div class="text-sm text-muted-foreground">Manage users and trust levels</div>
+            </div>
+          </a>
+
+          <a
+            href="/admin/tags"
+            class="card-civic hover:shadow-lg transition-shadow flex items-center gap-4"
+            data-testid="link-tags"
+          >
+            <div
+              class="w-12 h-12 bg-[var(--color-secondary)] flex items-center justify-center rounded-full"
+            >
+              <svg
+                class="w-6 h-6 text-[var(--color-civic-navy)]"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"
+                ></path>
+              </svg>
+            </div>
+            <div>
+              <div class="font-semibold text-[var(--color-civic-navy)]">Tag Suggestions</div>
+              <div class="text-sm text-muted-foreground">
+                {stats.pendingTags > 0 ? `${stats.pendingTags} pending` : "Review suggested tags"}
+              </div>
             </div>
           </a>
         </div>

--- a/src/pages/admin/tags.astro
+++ b/src/pages/admin/tags.astro
@@ -1,0 +1,192 @@
+---
+export const prerender = false;
+
+import Layout from "@/layouts/Layout.astro";
+import Header from "@/components/Header.astro";
+import Footer from "@/components/Footer.astro";
+import { createDb } from "@/db/client";
+import { tagSuggestions, users } from "@/db/schema";
+import { eq, desc } from "drizzle-orm";
+import { getRequiredEnv } from "@/lib/env";
+import { isAdmin } from "@/lib/admin";
+
+const user = Astro.locals.user;
+
+if (!user) {
+  return Astro.redirect("/?login=required");
+}
+
+if (!isAdmin(user)) {
+  return new Response(null, { status: 403 });
+}
+
+type TagItem = {
+  id: string;
+  name: string;
+  status: string;
+  suggestedBy: string | null;
+  suggestedByEmail: string | null;
+  createdAt: Date;
+};
+
+let pendingTags: TagItem[] = [];
+
+try {
+  const db = createDb(getRequiredEnv(Astro.locals, "DATABASE_URL"));
+
+  const results = await db
+    .select({
+      id: tagSuggestions.id,
+      name: tagSuggestions.name,
+      status: tagSuggestions.status,
+      suggestedBy: tagSuggestions.suggestedBy,
+      suggestedByEmail: users.emailHash,
+      createdAt: tagSuggestions.createdAt,
+    })
+    .from(tagSuggestions)
+    .leftJoin(users, eq(tagSuggestions.suggestedBy, users.id))
+    .where(eq(tagSuggestions.status, "pending"))
+    .orderBy(desc(tagSuggestions.createdAt));
+
+  pendingTags = results;
+} catch (error) {
+  console.error("Failed to load tag suggestions:", error);
+}
+
+function formatDate(date: Date): string {
+  return new Date(date).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+---
+
+<Layout title="Tag Suggestions">
+  <Header currentPath="/admin" user={user} />
+
+  <main class="flex-1 py-12">
+    <div class="container mx-auto px-4">
+      <div class="max-w-4xl mx-auto">
+        <div class="flex items-center justify-between mb-8">
+          <div>
+            <h1 class="text-2xl md:text-3xl font-bold text-[var(--color-civic-navy)]">
+              Tag Suggestions
+            </h1>
+            <p class="text-muted-foreground mt-1">
+              {pendingTags.length} tags awaiting review
+            </p>
+          </div>
+          <a href="/admin" class="btn-secondary">Back to Dashboard</a>
+        </div>
+
+        <div data-testid="tag-items" class="space-y-4">
+          {
+            pendingTags.length > 0 ? (
+              pendingTags.map((tag) => (
+                <article data-testid="tag-item" class="card-civic" data-tag-id={tag.id}>
+                  <div class="flex items-center justify-between">
+                    <div class="flex-1">
+                      <div class="flex items-center gap-3 mb-2">
+                        <span class="inline-flex items-center px-3 py-1 rounded-full bg-[var(--color-secondary)] text-[var(--color-civic-navy)] font-medium">
+                          {tag.name}
+                        </span>
+                        <span class="px-2 py-1 text-xs rounded bg-yellow-100 text-yellow-700">
+                          Pending
+                        </span>
+                      </div>
+                      <p class="text-sm text-muted-foreground">
+                        Suggested {formatDate(tag.createdAt)}
+                        {tag.suggestedByEmail && ` by user ${tag.suggestedByEmail.slice(0, 8)}...`}
+                      </p>
+                    </div>
+                    <div class="flex gap-2">
+                      <button
+                        type="button"
+                        class="btn-primary text-sm bg-green-600 hover:bg-green-700 tag-action-btn"
+                        data-testid="approve-button"
+                        data-action="approve"
+                      >
+                        Approve
+                      </button>
+                      <button
+                        type="button"
+                        class="btn-secondary text-sm text-red-600 hover:bg-red-50 tag-action-btn"
+                        data-testid="reject-button"
+                        data-action="reject"
+                      >
+                        Reject
+                      </button>
+                    </div>
+                  </div>
+                </article>
+              ))
+            ) : (
+              <div class="text-center py-12">
+                <div class="w-16 h-16 mx-auto mb-6 bg-green-100 flex items-center justify-center rounded-full">
+                  <svg
+                    class="w-8 h-8 text-green-600"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M5 13l4 4L19 7"
+                    />
+                  </svg>
+                </div>
+                <p class="text-muted-foreground">
+                  All caught up! No tag suggestions pending review.
+                </p>
+              </div>
+            )
+          }
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <Footer currentPath="/admin" />
+</Layout>
+
+<script is:inline>
+  document.addEventListener("click", async function (e) {
+    const button = e.target.closest(".tag-action-btn");
+    if (!button) return;
+
+    const article = button.closest("[data-tag-id]");
+    if (!article) return;
+
+    const tagId = article.getAttribute("data-tag-id");
+    const action = button.getAttribute("data-action");
+    if (!tagId || !action) return;
+
+    try {
+      const response = await fetch("/api/admin/tags", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tagId, action }),
+      });
+
+      if (response.ok) {
+        article.remove();
+        const countEl = document.querySelector('[data-testid="tag-items"]');
+        const remaining = countEl?.querySelectorAll('[data-testid="tag-item"]').length ?? 0;
+        const headerP = document.querySelector("main h1 + p");
+        if (headerP) {
+          headerP.textContent = `${remaining} tags awaiting review`;
+        }
+      } else {
+        const data = await response.json();
+        alert(data.error || `Failed to ${action} tag`);
+      }
+    } catch {
+      alert(`Failed to ${action} tag`);
+    }
+  });
+</script>

--- a/src/pages/api/admin/tags.ts
+++ b/src/pages/api/admin/tags.ts
@@ -1,0 +1,76 @@
+import type { APIRoute } from "astro";
+import { eq, desc } from "drizzle-orm";
+import { createDb } from "@/db/client";
+import { tagSuggestions } from "@/db/schema";
+import { jsonResponse, badRequest, serverError, notFound } from "@/lib/api-response";
+import { getRequiredEnv } from "@/lib/env";
+import { requireAdmin } from "@/lib/admin";
+import { z } from "zod";
+
+export const prerender = false;
+
+const actionSchema = z.object({
+  tagId: z.string().uuid(),
+  action: z.enum(["approve", "reject"]),
+});
+
+export const GET: APIRoute = async ({ locals }) => {
+  const adminError = requireAdmin(locals.user);
+  if (adminError) return adminError;
+
+  try {
+    const db = createDb(getRequiredEnv(locals, "DATABASE_URL"));
+    const tags = await db
+      .select()
+      .from(tagSuggestions)
+      .where(eq(tagSuggestions.status, "pending"))
+      .orderBy(desc(tagSuggestions.createdAt));
+
+    return jsonResponse({ tags });
+  } catch (error) {
+    console.error("Failed to fetch tag suggestions:", error);
+    return serverError("Failed to fetch tag suggestions");
+  }
+};
+
+export const POST: APIRoute = async ({ locals, request }) => {
+  const adminError = requireAdmin(locals.user);
+  if (adminError) return adminError;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return badRequest("Invalid JSON");
+  }
+
+  const result = actionSchema.safeParse(body);
+  if (!result.success) {
+    return badRequest("Invalid request body");
+  }
+
+  const { tagId, action } = result.data;
+  const newStatus = action === "approve" ? "approved" : "rejected";
+
+  try {
+    const db = createDb(getRequiredEnv(locals, "DATABASE_URL"));
+    const [updatedTag] = await db
+      .update(tagSuggestions)
+      .set({
+        status: newStatus,
+        approvedBy: locals.user?.id ?? null,
+        updatedAt: new Date(),
+      })
+      .where(eq(tagSuggestions.id, tagId))
+      .returning();
+
+    if (!updatedTag) {
+      return notFound("Tag suggestion not found");
+    }
+
+    return jsonResponse({ tag: updatedTag });
+  } catch (error) {
+    console.error("Failed to update tag suggestion:", error);
+    return serverError("Failed to update tag suggestion");
+  }
+};

--- a/src/pages/api/tags/index.ts
+++ b/src/pages/api/tags/index.ts
@@ -1,0 +1,23 @@
+import type { APIRoute } from "astro";
+import { eq } from "drizzle-orm";
+import { createDb } from "@/db/client";
+import { tagSuggestions } from "@/db/schema";
+import { jsonResponse, serverError } from "@/lib/api-response";
+import { getRequiredEnv } from "@/lib/env";
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ locals }) => {
+  try {
+    const db = createDb(getRequiredEnv(locals, "DATABASE_URL"));
+    const tags = await db
+      .select({ name: tagSuggestions.name })
+      .from(tagSuggestions)
+      .where(eq(tagSuggestions.status, "approved"));
+
+    return jsonResponse({ tags: tags.map((t) => t.name) });
+  } catch (error) {
+    console.error("Failed to fetch tags:", error);
+    return serverError("Failed to fetch tags");
+  }
+};

--- a/src/pages/api/tags/suggest.ts
+++ b/src/pages/api/tags/suggest.ts
@@ -1,0 +1,62 @@
+import type { APIRoute } from "astro";
+import { eq, or } from "drizzle-orm";
+import { createDb } from "@/db/client";
+import { tagSuggestions } from "@/db/schema";
+import { jsonResponse, badRequest, conflict, serverError } from "@/lib/api-response";
+import { getRequiredEnv } from "@/lib/env";
+import { z } from "zod";
+
+export const prerender = false;
+
+const suggestSchema = z.object({
+  name: z
+    .string()
+    .min(2, "Tag name must be at least 2 characters")
+    .max(50, "Tag name must be at most 50 characters")
+    .regex(/^[a-z0-9-]+$/, "Tag name must be lowercase alphanumeric with hyphens only")
+    .transform((s) => s.toLowerCase().trim()),
+});
+
+export const POST: APIRoute = async ({ locals, request }) => {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return badRequest("Invalid JSON");
+  }
+
+  const result = suggestSchema.safeParse(body);
+  if (!result.success) {
+    return badRequest(result.error.issues[0]?.message ?? "Invalid tag name");
+  }
+
+  const { name } = result.data;
+
+  try {
+    const db = createDb(getRequiredEnv(locals, "DATABASE_URL"));
+
+    const existing = await db
+      .select()
+      .from(tagSuggestions)
+      .where(or(eq(tagSuggestions.name, name), eq(tagSuggestions.status, "approved")));
+
+    const existingWithName = existing.find((t) => t.name === name);
+    if (existingWithName) {
+      return conflict("Tag already exists or is pending review");
+    }
+
+    const [newTag] = await db
+      .insert(tagSuggestions)
+      .values({
+        name,
+        suggestedBy: locals.user?.id ?? null,
+        status: "pending",
+      })
+      .returning();
+
+    return jsonResponse({ tag: newTag });
+  } catch (error) {
+    console.error("Failed to suggest tag:", error);
+    return serverError("Failed to suggest tag");
+  }
+};

--- a/tests/api/admin/tags.test.ts
+++ b/tests/api/admin/tags.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET, POST } from "@/pages/api/admin/tags";
+
+vi.mock("@/db/client", () => ({
+  createDb: vi.fn(() => mockDb),
+}));
+
+const mockDb = {
+  select: vi.fn().mockReturnThis(),
+  from: vi.fn().mockReturnThis(),
+  where: vi.fn().mockReturnThis(),
+  orderBy: vi.fn(),
+  insert: vi.fn().mockReturnThis(),
+  values: vi.fn().mockReturnThis(),
+  returning: vi.fn(),
+  update: vi.fn().mockReturnThis(),
+  set: vi.fn().mockReturnThis(),
+};
+
+function resetMockDb() {
+  Object.values(mockDb).forEach((fn) => fn.mockReset());
+  mockDb.select.mockReturnThis();
+  mockDb.from.mockReturnThis();
+  mockDb.where.mockReturnThis();
+  mockDb.insert.mockReturnThis();
+  mockDb.values.mockReturnThis();
+  mockDb.update.mockReturnThis();
+  mockDb.set.mockReturnThis();
+}
+
+const adminLocals = {
+  user: { id: "admin-123", trustLevel: 2 },
+  runtime: { env: { DATABASE_URL: "postgres://test" } },
+};
+
+const nonAdminLocals = {
+  user: { id: "user-456", trustLevel: 0 },
+  runtime: { env: { DATABASE_URL: "postgres://test" } },
+};
+
+describe("Tag Suggestions Admin API", () => {
+  beforeEach(() => {
+    resetMockDb();
+  });
+
+  describe("GET /api/admin/tags", () => {
+    it("returns 403 for non-admin users", async () => {
+      const response = await GET({ locals: nonAdminLocals } as never);
+      expect(response.status).toBe(403);
+    });
+
+    it("returns pending tag suggestions for admin", async () => {
+      const mockTags = [
+        { id: "1", name: "healthcare", status: "pending", createdAt: new Date() },
+        { id: "2", name: "education", status: "pending", createdAt: new Date() },
+      ];
+      mockDb.orderBy.mockResolvedValue(mockTags);
+
+      const response = await GET({ locals: adminLocals } as never);
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.tags).toHaveLength(2);
+    });
+  });
+
+  describe("POST /api/admin/tags", () => {
+    const validTagId = "550e8400-e29b-41d4-a716-446655440000";
+
+    it("returns 403 for non-admin users", async () => {
+      const response = await POST({
+        locals: nonAdminLocals,
+        request: new Request("http://localhost/api/admin/tags", {
+          method: "POST",
+          body: JSON.stringify({ tagId: validTagId, action: "approve" }),
+        }),
+      } as never);
+      expect(response.status).toBe(403);
+    });
+
+    it("approves tag suggestion when admin clicks approve", async () => {
+      mockDb.returning.mockResolvedValue([
+        { id: validTagId, name: "healthcare", status: "approved" },
+      ]);
+
+      const response = await POST({
+        locals: adminLocals,
+        request: new Request("http://localhost/api/admin/tags", {
+          method: "POST",
+          body: JSON.stringify({ tagId: validTagId, action: "approve" }),
+        }),
+      } as never);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.tag.status).toBe("approved");
+    });
+
+    it("rejects tag suggestion when admin clicks reject", async () => {
+      mockDb.returning.mockResolvedValue([{ id: validTagId, name: "spam", status: "rejected" }]);
+
+      const response = await POST({
+        locals: adminLocals,
+        request: new Request("http://localhost/api/admin/tags", {
+          method: "POST",
+          body: JSON.stringify({ tagId: validTagId, action: "reject" }),
+        }),
+      } as never);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.tag.status).toBe("rejected");
+    });
+  });
+});

--- a/tests/api/tags/suggest.test.ts
+++ b/tests/api/tags/suggest.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "@/pages/api/tags/suggest";
+
+vi.mock("@/db/client", () => ({
+  createDb: vi.fn(() => mockDb),
+}));
+
+const mockDb = {
+  select: vi.fn().mockReturnThis(),
+  from: vi.fn().mockReturnThis(),
+  where: vi.fn(),
+  insert: vi.fn().mockReturnThis(),
+  values: vi.fn().mockReturnThis(),
+  returning: vi.fn(),
+};
+
+function resetMockDb() {
+  Object.values(mockDb).forEach((fn) => fn.mockReset());
+  mockDb.select.mockReturnThis();
+  mockDb.from.mockReturnThis();
+  mockDb.insert.mockReturnThis();
+  mockDb.values.mockReturnThis();
+}
+
+const createLocals = (userId: string | null) => ({
+  user: userId ? { id: userId } : null,
+  runtime: { env: { DATABASE_URL: "postgres://test" } },
+});
+
+describe("Tag Suggestion API", () => {
+  beforeEach(() => {
+    resetMockDb();
+  });
+
+  describe("POST /api/tags/suggest", () => {
+    it("creates tag suggestion for authenticated user", async () => {
+      mockDb.where.mockResolvedValue([]);
+      mockDb.returning.mockResolvedValue([
+        { id: "1", name: "healthcare", status: "pending", suggestedBy: "user-123" },
+      ]);
+
+      const response = await POST({
+        locals: createLocals("user-123"),
+        request: new Request("http://localhost/api/tags/suggest", {
+          method: "POST",
+          body: JSON.stringify({ name: "healthcare" }),
+        }),
+      } as never);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.tag.name).toBe("healthcare");
+      expect(data.tag.status).toBe("pending");
+    });
+
+    it("allows anonymous tag suggestions", async () => {
+      mockDb.where.mockResolvedValue([]);
+      mockDb.returning.mockResolvedValue([
+        { id: "1", name: "education", status: "pending", suggestedBy: null },
+      ]);
+
+      const response = await POST({
+        locals: createLocals(null),
+        request: new Request("http://localhost/api/tags/suggest", {
+          method: "POST",
+          body: JSON.stringify({ name: "education" }),
+        }),
+      } as never);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.tag.name).toBe("education");
+    });
+
+    it("returns 400 for invalid tag name", async () => {
+      const response = await POST({
+        locals: createLocals("user-123"),
+        request: new Request("http://localhost/api/tags/suggest", {
+          method: "POST",
+          body: JSON.stringify({ name: "" }),
+        }),
+      } as never);
+
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 409 if tag already exists", async () => {
+      mockDb.where.mockResolvedValue([{ id: "existing", name: "healthcare" }]);
+
+      const response = await POST({
+        locals: createLocals("user-123"),
+        request: new Request("http://localhost/api/tags/suggest", {
+          method: "POST",
+          body: JSON.stringify({ name: "healthcare" }),
+        }),
+      } as never);
+
+      expect(response.status).toBe(409);
+      const data = await response.json();
+      expect(data.error).toContain("already exists");
+    });
+  });
+});

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -22,5 +22,27 @@ test.describe("Admin Dashboard", () => {
     await expect(page.getByTestId("stat-templates")).toBeVisible();
     await expect(page.getByTestId("link-queue")).toBeVisible();
     await expect(page.getByTestId("link-users")).toBeVisible();
+    await expect(page.getByTestId("link-tags")).toBeVisible();
+  });
+});
+
+test.describe("Admin Tag Suggestions", () => {
+  test("non-admin is redirected from tags page", async ({ page }) => {
+    await page.goto("/admin/tags");
+
+    await expect(page).toHaveURL(/\?login=required/);
+  });
+
+  test("admin can manage tag suggestions", async ({ page }) => {
+    test.skip(true, "Requires admin session setup with pending tag suggestions");
+
+    await page.goto("/admin/tags");
+
+    await expect(page.getByText("Tag Suggestions")).toBeVisible();
+    await expect(page.getByTestId("tag-items")).toBeVisible();
+
+    const tagItem = page.getByTestId("tag-item").first();
+    await expect(tagItem.getByTestId("approve-button")).toBeVisible();
+    await expect(tagItem.getByTestId("reject-button")).toBeVisible();
   });
 });

--- a/tests/schema-tag-suggestions.test.ts
+++ b/tests/schema-tag-suggestions.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { getTableColumns } from "drizzle-orm";
+import { tagSuggestions } from "../src/db/schema";
+
+describe("Phase 7.6: Tag Suggestions table schema", () => {
+  const columns = getTableColumns(tagSuggestions);
+
+  it("should have id as primary key (UUID)", () => {
+    expect(columns.id).toBeDefined();
+    expect(columns.id.primary).toBe(true);
+  });
+
+  it("should have name field", () => {
+    expect(columns.name).toBeDefined();
+  });
+
+  it("should have suggestedBy foreign key to users", () => {
+    expect(columns.suggestedBy).toBeDefined();
+  });
+
+  it("should have status field", () => {
+    expect(columns.status).toBeDefined();
+  });
+
+  it("should have approvedBy foreign key to users", () => {
+    expect(columns.approvedBy).toBeDefined();
+  });
+
+  it("should have timestamps", () => {
+    expect(columns.createdAt).toBeDefined();
+    expect(columns.updatedAt).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `tag_suggestions` database table with pending/approved/rejected workflow
- Creates public API endpoints for suggesting tags (`POST /api/tags/suggest`) and listing approved tags (`GET /api/tags`)
- Creates admin API endpoint for approving/rejecting suggestions (`GET/POST /api/admin/tags`)
- Adds admin UI page at `/admin/tags` for reviewing tag suggestions
- Updates admin dashboard with link to tag management and pending count

## Test plan

- [x] Run `pnpm test` - all 402 tests pass
- [x] Run `pnpm lint && pnpm format:check && pnpm typecheck` - all pass
- [ ] CI pipeline passes
- [ ] Copilot review approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)