### PR TITLE
fix: Use correct path for check_run head_branch

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -20,7 +20,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.check_run.app.slug == 'cloudflare-workers-and-pages' &&
        github.event.check_run.conclusion == 'success' &&
-       github.event.check_run.head_branch == 'main')
+       github.event.check_run.check_suite.head_branch == 'main')
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
Fix smoke test workflow skipping on check_run events.

The branch name is at `github.event.check_run.check_suite.head_branch`, not `github.event.check_run.head_branch`.

## Test plan
- [ ] Merge and verify workflow triggers after next Cloudflare deployment

🤖 Generated with [Claude Code](https://claude.ai/code)