### PR TITLE
fix: Separate concurrency groups for PR and push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -240,14 +240,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Create backup branch before migration
-        id: create_backup
-        uses: neondatabase/create-branch-action@72ed4f69a12b6be9c16aebfad893f6a21e9aba8b # v6
-        with:
-          project_id: ${{ vars.NEON_PROJECT_ID }}
-          branch_name: backup/pre-migration-${{ github.sha }}
-          api_key: ${{ secrets.NEON_API_KEY }}
 
       - name: Run migrations
         run: pnpm db:migrate


### PR DESCRIPTION
## Summary

- Add `github.event_name` to concurrency group key
- Remove backup branch creation before migrations (rely on Neon's 6-hour PITR instead)

## Problem

When a PR is merged, both events fire with `github.ref = refs/heads/main`:
- `pull_request: closed`
- `push`

With the old concurrency group, they shared the same group and `cancel-in-progress: true` cancelled the cleanup job.

Also, creating backup branches before each migration would quickly exhaust the 10-branch limit on the free plan.

## Fix

- New concurrency group: `workflow-event_name-ref` (separates PR and push events)
- Use Neon's built-in 6-hour PITR for rollbacks instead of backup branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)