### PR TITLE
Complete UUID v4 → v7 migration (swap phase)

### DIFF
--- a/drizzle/0015_swap-v4-to-v7-ids.sql
+++ b/drizzle/0015_swap-v4-to-v7-ids.sql
@@ -1,0 +1,246 @@
+-- Phase 1: Drop all 15 FK constraints
+--> statement-breakpoint
+ALTER TABLE "sessions" DROP CONSTRAINT "sessions_user_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "templates" DROP CONSTRAINT "templates_user_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "template_flags" DROP CONSTRAINT "template_flags_user_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "moderation_log" DROP CONSTRAINT "moderation_log_admin_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "issue_tags" DROP CONSTRAINT "tag_suggestions_suggested_by_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "issue_tags" DROP CONSTRAINT "tag_suggestions_approved_by_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "user_templates" DROP CONSTRAINT "user_templates_user_id_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "template_flags" DROP CONSTRAINT "template_flags_template_id_templates_id_fk";
+--> statement-breakpoint
+ALTER TABLE "moderation_log" DROP CONSTRAINT "moderation_log_template_id_templates_id_fk";
+--> statement-breakpoint
+ALTER TABLE "template_issue_tags" DROP CONSTRAINT "template_issue_tags_template_id_fkey";
+--> statement-breakpoint
+ALTER TABLE "user_templates" DROP CONSTRAINT "user_templates_template_id_templates_id_fk";
+--> statement-breakpoint
+ALTER TABLE "template_uses" DROP CONSTRAINT "template_uses_template_id_templates_id_fk";
+--> statement-breakpoint
+ALTER TABLE "member_votes" DROP CONSTRAINT "member_votes_vote_id_votes_id_fk";
+--> statement-breakpoint
+ALTER TABLE "amendments" DROP CONSTRAINT "amendments_amended_bill_id_bills_id_fk";
+--> statement-breakpoint
+ALTER TABLE "template_issue_tags" DROP CONSTRAINT "template_issue_tags_issue_tag_id_fkey";
+--> statement-breakpoint
+
+-- Phase 2: Drop 3 composite PKs (contain FK columns)
+--> statement-breakpoint
+ALTER TABLE "member_votes" DROP CONSTRAINT "member_votes_vote_id_bioguide_id_pk";
+--> statement-breakpoint
+ALTER TABLE "user_templates" DROP CONSTRAINT "user_templates_user_id_template_id_pk";
+--> statement-breakpoint
+ALTER TABLE "template_issue_tags" DROP CONSTRAINT "template_issue_tags_pkey";
+--> statement-breakpoint
+
+-- Phase 3: Drop 11 single-column PKs
+--> statement-breakpoint
+ALTER TABLE "users" DROP CONSTRAINT "users_pkey";
+--> statement-breakpoint
+ALTER TABLE "email_otps" DROP CONSTRAINT "email_otps_pkey";
+--> statement-breakpoint
+ALTER TABLE "sessions" DROP CONSTRAINT "sessions_pkey";
+--> statement-breakpoint
+ALTER TABLE "templates" DROP CONSTRAINT "templates_pkey";
+--> statement-breakpoint
+ALTER TABLE "template_flags" DROP CONSTRAINT "template_flags_pkey";
+--> statement-breakpoint
+ALTER TABLE "moderation_log" DROP CONSTRAINT "moderation_log_pkey";
+--> statement-breakpoint
+ALTER TABLE "issue_tags" DROP CONSTRAINT "tag_suggestions_pkey";
+--> statement-breakpoint
+ALTER TABLE "votes" DROP CONSTRAINT "votes_pkey";
+--> statement-breakpoint
+ALTER TABLE "bills" DROP CONSTRAINT "bills_pkey";
+--> statement-breakpoint
+ALTER TABLE "amendments" DROP CONSTRAINT "amendments_pkey";
+--> statement-breakpoint
+ALTER TABLE "template_uses" DROP CONSTRAINT "template_uses_pkey";
+--> statement-breakpoint
+
+-- Phase 4: Update 18 FK columns via UPDATE ... FROM ... WHERE
+--> statement-breakpoint
+UPDATE "sessions" SET "user_id" = u."v7_id" FROM "users" u WHERE "sessions"."user_id" = u."id";
+--> statement-breakpoint
+UPDATE "templates" SET "user_id" = u."v7_id" FROM "users" u WHERE "templates"."user_id" = u."id";
+--> statement-breakpoint
+UPDATE "template_flags" SET "user_id" = u."v7_id" FROM "users" u WHERE "template_flags"."user_id" = u."id";
+--> statement-breakpoint
+UPDATE "moderation_log" SET "admin_id" = u."v7_id" FROM "users" u WHERE "moderation_log"."admin_id" = u."id";
+--> statement-breakpoint
+UPDATE "issue_tags" SET "suggested_by" = u."v7_id" FROM "users" u WHERE "issue_tags"."suggested_by" = u."id";
+--> statement-breakpoint
+UPDATE "issue_tags" SET "approved_by" = u."v7_id" FROM "users" u WHERE "issue_tags"."approved_by" = u."id";
+--> statement-breakpoint
+UPDATE "user_templates" SET "user_id" = u."v7_id" FROM "users" u WHERE "user_templates"."user_id" = u."id";
+--> statement-breakpoint
+UPDATE "template_flags" SET "template_id" = t."v7_id" FROM "templates" t WHERE "template_flags"."template_id" = t."id";
+--> statement-breakpoint
+UPDATE "moderation_log" SET "template_id" = t."v7_id" FROM "templates" t WHERE "moderation_log"."template_id" = t."id";
+--> statement-breakpoint
+UPDATE "template_issue_tags" SET "template_id" = t."v7_id" FROM "templates" t WHERE "template_issue_tags"."template_id" = t."id";
+--> statement-breakpoint
+UPDATE "user_templates" SET "template_id" = t."v7_id" FROM "templates" t WHERE "user_templates"."template_id" = t."id";
+--> statement-breakpoint
+UPDATE "template_uses" SET "template_id" = t."v7_id" FROM "templates" t WHERE "template_uses"."template_id" = t."id";
+--> statement-breakpoint
+UPDATE "member_votes" SET "vote_id" = v."v7_id" FROM "votes" v WHERE "member_votes"."vote_id" = v."id";
+--> statement-breakpoint
+UPDATE "amendments" SET "amended_bill_id" = b."v7_id" FROM "bills" b WHERE "amendments"."amended_bill_id" = b."id";
+--> statement-breakpoint
+UPDATE "template_issue_tags" SET "issue_tag_id" = it."v7_id" FROM "issue_tags" it WHERE "template_issue_tags"."issue_tag_id" = it."id";
+--> statement-breakpoint
+UPDATE "votes" SET "bill_id" = b."v7_id" FROM "bills" b WHERE "votes"."bill_id" = b."id";
+--> statement-breakpoint
+UPDATE "votes" SET "amendment_id" = a."v7_id" FROM "amendments" a WHERE "votes"."amendment_id" = a."id";
+--> statement-breakpoint
+UPDATE "templates" SET "forked_from" = t2."v7_id" FROM "templates" t2 WHERE "templates"."forked_from" = t2."id";
+--> statement-breakpoint
+
+-- Phase 5: Copy v7_id → id for all 11 tables
+--> statement-breakpoint
+UPDATE "users" SET "id" = "v7_id";
+--> statement-breakpoint
+UPDATE "email_otps" SET "id" = "v7_id";
+--> statement-breakpoint
+UPDATE "sessions" SET "id" = "v7_id";
+--> statement-breakpoint
+UPDATE "templates" SET "id" = "v7_id";
+--> statement-breakpoint
+UPDATE "template_flags" SET "id" = "v7_id";
+--> statement-breakpoint
+UPDATE "moderation_log" SET "id" = "v7_id";
+--> statement-breakpoint
+UPDATE "issue_tags" SET "id" = "v7_id";
+--> statement-breakpoint
+UPDATE "votes" SET "id" = "v7_id";
+--> statement-breakpoint
+UPDATE "bills" SET "id" = "v7_id";
+--> statement-breakpoint
+UPDATE "amendments" SET "id" = "v7_id";
+--> statement-breakpoint
+UPDATE "template_uses" SET "id" = "v7_id";
+--> statement-breakpoint
+
+-- Phase 6: Change defaults to uuid_generate_v7()
+--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "id" SET DEFAULT uuid_generate_v7();
+--> statement-breakpoint
+ALTER TABLE "email_otps" ALTER COLUMN "id" SET DEFAULT uuid_generate_v7();
+--> statement-breakpoint
+ALTER TABLE "sessions" ALTER COLUMN "id" SET DEFAULT uuid_generate_v7();
+--> statement-breakpoint
+ALTER TABLE "templates" ALTER COLUMN "id" SET DEFAULT uuid_generate_v7();
+--> statement-breakpoint
+ALTER TABLE "template_flags" ALTER COLUMN "id" SET DEFAULT uuid_generate_v7();
+--> statement-breakpoint
+ALTER TABLE "moderation_log" ALTER COLUMN "id" SET DEFAULT uuid_generate_v7();
+--> statement-breakpoint
+ALTER TABLE "issue_tags" ALTER COLUMN "id" SET DEFAULT uuid_generate_v7();
+--> statement-breakpoint
+ALTER TABLE "votes" ALTER COLUMN "id" SET DEFAULT uuid_generate_v7();
+--> statement-breakpoint
+ALTER TABLE "bills" ALTER COLUMN "id" SET DEFAULT uuid_generate_v7();
+--> statement-breakpoint
+ALTER TABLE "amendments" ALTER COLUMN "id" SET DEFAULT uuid_generate_v7();
+--> statement-breakpoint
+ALTER TABLE "template_uses" ALTER COLUMN "id" SET DEFAULT uuid_generate_v7();
+--> statement-breakpoint
+
+-- Phase 7: Restore 11 single-column PKs
+--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_pkey" PRIMARY KEY ("id");
+--> statement-breakpoint
+ALTER TABLE "email_otps" ADD CONSTRAINT "email_otps_pkey" PRIMARY KEY ("id");
+--> statement-breakpoint
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_pkey" PRIMARY KEY ("id");
+--> statement-breakpoint
+ALTER TABLE "templates" ADD CONSTRAINT "templates_pkey" PRIMARY KEY ("id");
+--> statement-breakpoint
+ALTER TABLE "template_flags" ADD CONSTRAINT "template_flags_pkey" PRIMARY KEY ("id");
+--> statement-breakpoint
+ALTER TABLE "moderation_log" ADD CONSTRAINT "moderation_log_pkey" PRIMARY KEY ("id");
+--> statement-breakpoint
+ALTER TABLE "issue_tags" ADD CONSTRAINT "tag_suggestions_pkey" PRIMARY KEY ("id");
+--> statement-breakpoint
+ALTER TABLE "votes" ADD CONSTRAINT "votes_pkey" PRIMARY KEY ("id");
+--> statement-breakpoint
+ALTER TABLE "bills" ADD CONSTRAINT "bills_pkey" PRIMARY KEY ("id");
+--> statement-breakpoint
+ALTER TABLE "amendments" ADD CONSTRAINT "amendments_pkey" PRIMARY KEY ("id");
+--> statement-breakpoint
+ALTER TABLE "template_uses" ADD CONSTRAINT "template_uses_pkey" PRIMARY KEY ("id");
+--> statement-breakpoint
+
+-- Phase 8: Restore 3 composite PKs
+--> statement-breakpoint
+ALTER TABLE "member_votes" ADD CONSTRAINT "member_votes_vote_id_bioguide_id_pk" PRIMARY KEY ("vote_id", "bioguide_id");
+--> statement-breakpoint
+ALTER TABLE "user_templates" ADD CONSTRAINT "user_templates_user_id_template_id_pk" PRIMARY KEY ("user_id", "template_id");
+--> statement-breakpoint
+ALTER TABLE "template_issue_tags" ADD CONSTRAINT "template_issue_tags_pkey" PRIMARY KEY ("template_id", "issue_tag_id");
+--> statement-breakpoint
+
+-- Phase 9: Restore 15 FK constraints
+--> statement-breakpoint
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "templates" ADD CONSTRAINT "templates_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+ALTER TABLE "template_flags" ADD CONSTRAINT "template_flags_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+ALTER TABLE "moderation_log" ADD CONSTRAINT "moderation_log_admin_id_users_id_fk" FOREIGN KEY ("admin_id") REFERENCES "users"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+ALTER TABLE "issue_tags" ADD CONSTRAINT "tag_suggestions_suggested_by_users_id_fk" FOREIGN KEY ("suggested_by") REFERENCES "users"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+ALTER TABLE "issue_tags" ADD CONSTRAINT "tag_suggestions_approved_by_users_id_fk" FOREIGN KEY ("approved_by") REFERENCES "users"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+ALTER TABLE "user_templates" ADD CONSTRAINT "user_templates_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "template_flags" ADD CONSTRAINT "template_flags_template_id_templates_id_fk" FOREIGN KEY ("template_id") REFERENCES "templates"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "moderation_log" ADD CONSTRAINT "moderation_log_template_id_templates_id_fk" FOREIGN KEY ("template_id") REFERENCES "templates"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "template_issue_tags" ADD CONSTRAINT "template_issue_tags_template_id_fkey" FOREIGN KEY ("template_id") REFERENCES "templates"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "user_templates" ADD CONSTRAINT "user_templates_template_id_templates_id_fk" FOREIGN KEY ("template_id") REFERENCES "templates"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "template_uses" ADD CONSTRAINT "template_uses_template_id_templates_id_fk" FOREIGN KEY ("template_id") REFERENCES "templates"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "member_votes" ADD CONSTRAINT "member_votes_vote_id_votes_id_fk" FOREIGN KEY ("vote_id") REFERENCES "votes"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "amendments" ADD CONSTRAINT "amendments_amended_bill_id_bills_id_fk" FOREIGN KEY ("amended_bill_id") REFERENCES "bills"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+ALTER TABLE "template_issue_tags" ADD CONSTRAINT "template_issue_tags_issue_tag_id_fkey" FOREIGN KEY ("issue_tag_id") REFERENCES "issue_tags"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+
+-- Phase 10: Drop 11 v7_id columns (cascades drop UNIQUE constraints)
+--> statement-breakpoint
+ALTER TABLE "users" DROP COLUMN "v7_id";
+--> statement-breakpoint
+ALTER TABLE "email_otps" DROP COLUMN "v7_id";
+--> statement-breakpoint
+ALTER TABLE "sessions" DROP COLUMN "v7_id";
+--> statement-breakpoint
+ALTER TABLE "templates" DROP COLUMN "v7_id";
+--> statement-breakpoint
+ALTER TABLE "template_flags" DROP COLUMN "v7_id";
+--> statement-breakpoint
+ALTER TABLE "moderation_log" DROP COLUMN "v7_id";
+--> statement-breakpoint
+ALTER TABLE "issue_tags" DROP COLUMN "v7_id";
+--> statement-breakpoint
+ALTER TABLE "votes" DROP COLUMN "v7_id";
+--> statement-breakpoint
+ALTER TABLE "bills" DROP COLUMN "v7_id";
+--> statement-breakpoint
+ALTER TABLE "amendments" DROP COLUMN "v7_id";
+--> statement-breakpoint
+ALTER TABLE "template_uses" DROP COLUMN "v7_id";

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,1935 @@
+{
+  "id": "cf0cb377-f215-4eed-ba8c-3192338d487e",
+  "prevId": "7461d999-823d-413e-81aa-d7655eb152f5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.amendments": {
+      "name": "amendments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "amendment_number": {
+          "name": "amendment_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amendment_type": {
+          "name": "amendment_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "congress": {
+          "name": "congress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chamber": {
+          "name": "chamber",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_action_date": {
+          "name": "latest_action_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_action_text": {
+          "name": "latest_action_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sponsor_bioguide_id": {
+          "name": "sponsor_bioguide_id",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amended_bill_id": {
+          "name": "amended_bill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "congress_gov_url": {
+          "name": "congress_gov_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "amendments_amended_bill_id_idx": {
+          "name": "amendments_amended_bill_id_idx",
+          "columns": [
+            {
+              "expression": "amended_bill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "amendments_congress_idx": {
+          "name": "amendments_congress_idx",
+          "columns": [
+            {
+              "expression": "congress",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "amendments_sponsor_bioguide_id_legislators_bioguide_id_fk": {
+          "name": "amendments_sponsor_bioguide_id_legislators_bioguide_id_fk",
+          "tableFrom": "amendments",
+          "columnsFrom": ["sponsor_bioguide_id"],
+          "tableTo": "legislators",
+          "columnsTo": ["bioguide_id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "amendments_amended_bill_id_bills_id_fk": {
+          "name": "amendments_amended_bill_id_bills_id_fk",
+          "tableFrom": "amendments",
+          "columnsFrom": ["amended_bill_id"],
+          "tableTo": "bills",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "amendments_congress_type_number_unique": {
+          "name": "amendments_congress_type_number_unique",
+          "columns": ["congress", "amendment_type", "amendment_number"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bills": {
+      "name": "bills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "bill_number": {
+          "name": "bill_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bill_type": {
+          "name": "bill_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "congress": {
+          "name": "congress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subjects": {
+          "name": "subjects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "introduced_date": {
+          "name": "introduced_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_action_date": {
+          "name": "latest_action_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_action_text": {
+          "name": "latest_action_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sponsor_bioguide_id": {
+          "name": "sponsor_bioguide_id",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "congress_gov_url": {
+          "name": "congress_gov_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bills_sponsor_bioguide_id_idx": {
+          "name": "bills_sponsor_bioguide_id_idx",
+          "columns": [
+            {
+              "expression": "sponsor_bioguide_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "bills_congress_latest_action_idx": {
+          "name": "bills_congress_latest_action_idx",
+          "columns": [
+            {
+              "expression": "congress",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "latest_action_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "bills_sponsor_bioguide_id_legislators_bioguide_id_fk": {
+          "name": "bills_sponsor_bioguide_id_legislators_bioguide_id_fk",
+          "tableFrom": "bills",
+          "columnsFrom": ["sponsor_bioguide_id"],
+          "tableTo": "legislators",
+          "columnsTo": ["bioguide_id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bills_congress_type_number_unique": {
+          "name": "bills_congress_type_number_unique",
+          "columns": ["congress", "bill_type", "bill_number"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_source_meta": {
+      "name": "data_source_meta",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_length": {
+          "name": "content_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checked": {
+          "name": "last_checked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_changed": {
+          "name": "last_changed",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_count": {
+          "name": "record_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_otps": {
+      "name": "email_otps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otp_hash": {
+          "name": "otp_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_attempts": {
+          "name": "verification_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_tags": {
+      "name": "issue_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_by": {
+          "name": "suggested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_tags_name_idx": {
+          "name": "issue_tags_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "issue_tags_status_idx": {
+          "name": "issue_tags_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "issue_tags_suggested_by_users_id_fk": {
+          "name": "issue_tags_suggested_by_users_id_fk",
+          "tableFrom": "issue_tags",
+          "columnsFrom": ["suggested_by"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "issue_tags_approved_by_users_id_fk": {
+          "name": "issue_tags_approved_by_users_id_fk",
+          "tableFrom": "issue_tags",
+          "columnsFrom": ["approved_by"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_tags_name_unique": {
+          "name": "issue_tags_name_unique",
+          "columns": ["name"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legislators": {
+      "name": "legislators",
+      "schema": "",
+      "columns": {
+        "bioguide_id": {
+          "name": "bioguide_id",
+          "type": "varchar(10)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "party": {
+          "name": "party",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "district": {
+          "name": "district",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chamber": {
+          "name": "chamber",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "term_start": {
+          "name": "term_start",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "term_end": {
+          "name": "term_end",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_capitol": {
+          "name": "phone_capitol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_district": {
+          "name": "phone_district",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fax": {
+          "name": "fax",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_capitol": {
+          "name": "address_capitol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_district": {
+          "name": "address_district",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_form_url": {
+          "name": "contact_form_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter_handle": {
+          "name": "twitter_handle",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facebook_id": {
+          "name": "facebook_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_id": {
+          "name": "youtube_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lis_id": {
+          "name": "lis_id",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "legislators_state_idx": {
+          "name": "legislators_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "legislators_state_district_idx": {
+          "name": "legislators_state_district_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "district",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_votes": {
+      "name": "member_votes",
+      "schema": "",
+      "columns": {
+        "vote_id": {
+          "name": "vote_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bioguide_id": {
+          "name": "bioguide_id",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_votes_bioguide_id_idx": {
+          "name": "member_votes_bioguide_id_idx",
+          "columns": [
+            {
+              "expression": "bioguide_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "member_votes_vote_id_votes_id_fk": {
+          "name": "member_votes_vote_id_votes_id_fk",
+          "tableFrom": "member_votes",
+          "columnsFrom": ["vote_id"],
+          "tableTo": "votes",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "member_votes_bioguide_id_legislators_bioguide_id_fk": {
+          "name": "member_votes_bioguide_id_legislators_bioguide_id_fk",
+          "tableFrom": "member_votes",
+          "columnsFrom": ["bioguide_id"],
+          "tableTo": "legislators",
+          "columnsTo": ["bioguide_id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "member_votes_vote_id_bioguide_id_pk": {
+          "name": "member_votes_vote_id_bioguide_id_pk",
+          "columns": ["vote_id", "bioguide_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.moderation_log": {
+      "name": "moderation_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_id": {
+          "name": "admin_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scores": {
+          "name": "scores",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "moderation_log_template_id_templates_id_fk": {
+          "name": "moderation_log_template_id_templates_id_fk",
+          "tableFrom": "moderation_log",
+          "columnsFrom": ["template_id"],
+          "tableTo": "templates",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "moderation_log_admin_id_users_id_fk": {
+          "name": "moderation_log_admin_id_users_id_fk",
+          "tableFrom": "moderation_log",
+          "columnsFrom": ["admin_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_cursors": {
+      "name": "sync_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oldest_congress": {
+          "name": "oldest_congress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newest_congress": {
+          "name": "newest_congress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_sync_congress": {
+          "name": "current_sync_congress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_offset": {
+          "name": "current_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template_flags": {
+      "name": "template_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_flags_template_user_idx": {
+          "name": "template_flags_template_user_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "template_flags_template_id_templates_id_fk": {
+          "name": "template_flags_template_id_templates_id_fk",
+          "tableFrom": "template_flags",
+          "columnsFrom": ["template_id"],
+          "tableTo": "templates",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "template_flags_user_id_users_id_fk": {
+          "name": "template_flags_user_id_users_id_fk",
+          "tableFrom": "template_flags",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template_issue_tags": {
+      "name": "template_issue_tags",
+      "schema": "",
+      "columns": {
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_tag_id": {
+          "name": "issue_tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_issue_tags_template_id_idx": {
+          "name": "template_issue_tags_template_id_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "template_issue_tags_issue_tag_id_idx": {
+          "name": "template_issue_tags_issue_tag_id_idx",
+          "columns": [
+            {
+              "expression": "issue_tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "template_issue_tags_template_id_templates_id_fk": {
+          "name": "template_issue_tags_template_id_templates_id_fk",
+          "tableFrom": "template_issue_tags",
+          "columnsFrom": ["template_id"],
+          "tableTo": "templates",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "template_issue_tags_issue_tag_id_issue_tags_id_fk": {
+          "name": "template_issue_tags_issue_tag_id_issue_tags_id_fk",
+          "tableFrom": "template_issue_tags",
+          "columnsFrom": ["issue_tag_id"],
+          "tableTo": "issue_tags",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "template_issue_tags_template_id_issue_tag_id_pk": {
+          "name": "template_issue_tags_template_id_issue_tag_id_pk",
+          "columns": ["template_id", "issue_tag_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template_uses": {
+      "name": "template_uses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rep_bioguide_id": {
+          "name": "rep_bioguide_id",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_type": {
+          "name": "contact_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitor_id": {
+          "name": "visitor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "template_uses_dedup_idx": {
+          "name": "template_uses_dedup_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rep_bioguide_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visitor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "template_uses_template_id_idx": {
+          "name": "template_uses_template_id_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "template_uses_template_id_templates_id_fk": {
+          "name": "template_uses_template_id_templates_id_fk",
+          "tableFrom": "template_uses",
+          "columnsFrom": ["template_id"],
+          "tableTo": "templates",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_tags": {
+          "name": "issue_tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "linked_bill_numbers": {
+          "name": "linked_bill_numbers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forked_from": {
+          "name": "forked_from",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_status": {
+          "name": "moderation_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "moderation_scores": {
+          "name": "moderation_scores",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "flag_count": {
+          "name": "flag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "templates_slug_idx": {
+          "name": "templates_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "templates_public_idx": {
+          "name": "templates_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "moderation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "templates_user_id_idx": {
+          "name": "templates_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "templates_moderation_idx": {
+          "name": "templates_moderation_idx",
+          "columns": [
+            {
+              "expression": "moderation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "templates_user_id_users_id_fk": {
+          "name": "templates_user_id_users_id_fk",
+          "tableFrom": "templates",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "templates_slug_unique": {
+          "name": "templates_slug_unique",
+          "columns": ["slug"],
+          "nullsNotDistinct": false
+        },
+        "templates_content_hash_unique": {
+          "name": "templates_content_hash_unique",
+          "columns": ["content_hash"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_templates": {
+      "name": "user_templates",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bookmarked_at": {
+          "name": "bookmarked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_templates_user_id_users_id_fk": {
+          "name": "user_templates_user_id_users_id_fk",
+          "tableFrom": "user_templates",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "user_templates_template_id_templates_id_fk": {
+          "name": "user_templates_template_id_templates_id_fk",
+          "tableFrom": "user_templates",
+          "columnsFrom": ["template_id"],
+          "tableTo": "templates",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_templates_user_id_template_id_pk": {
+          "name": "user_templates_user_id_template_id_pk",
+          "columns": ["user_id", "template_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trust_level": {
+          "name": "trust_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "approved_templates_count": {
+          "name": "approved_templates_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "saved_district": {
+          "name": "saved_district",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saved_state": {
+          "name": "saved_state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_hash_idx": {
+          "name": "users_email_hash_idx",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_hash_unique": {
+          "name": "users_email_hash_unique",
+          "columns": ["email_hash"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "roll_call": {
+          "name": "roll_call",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chamber": {
+          "name": "chamber",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "congress": {
+          "name": "congress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session": {
+          "name": "session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bill_number": {
+          "name": "bill_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_title": {
+          "name": "bill_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_subjects": {
+          "name": "bill_subjects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_id": {
+          "name": "bill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amendment_id": {
+          "name": "amendment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legislation_type": {
+          "name": "legislation_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "yeas": {
+          "name": "yeas",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "nays": {
+          "name": "nays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "not_voting": {
+          "name": "not_voting",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "present": {
+          "name": "present",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "votes_chamber_congress_idx": {
+          "name": "votes_chamber_congress_idx",
+          "columns": [
+            {
+              "expression": "chamber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "congress",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "votes_date_idx": {
+          "name": "votes_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "votes_bill_id_idx": {
+          "name": "votes_bill_id_idx",
+          "columns": [
+            {
+              "expression": "bill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "votes_amendment_id_idx": {
+          "name": "votes_amendment_id_idx",
+          "columns": [
+            {
+              "expression": "amendment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "votes_chamber_congress_session_rollcall_unique": {
+          "name": "votes_chamber_congress_session_rollcall_unique",
+          "columns": ["chamber", "congress", "session", "roll_call"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zip_districts": {
+      "name": "zip_districts",
+      "schema": "",
+      "columns": {
+        "zip": {
+          "name": "zip",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "district": {
+          "name": "district",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proportion": {
+          "name": "proportion",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "zip_districts_zip_idx": {
+          "name": "zip_districts_zip_idx",
+          "columns": [
+            {
+              "expression": "zip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "zip_districts_zip_state_district_pk": {
+          "name": "zip_districts_zip_state_district_pk",
+          "columns": ["zip", "state", "district"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1770774545957,
       "tag": "0014_add-v7-id-columns",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1771004690382,
+      "tag": "0015_swap-v4-to-v7-ids",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import {
   pgTable,
   text,
@@ -71,7 +72,9 @@ export const zipDistricts = pgTable(
 export const users = pgTable(
   "users",
   {
-    id: uuid("id").primaryKey().defaultRandom(),
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`uuid_generate_v7()`),
     emailHash: varchar("email_hash", { length: 64 }).notNull().unique(),
     trustLevel: integer("trust_level").notNull().default(0),
     approvedTemplatesCount: integer("approved_templates_count").notNull().default(0),
@@ -84,7 +87,9 @@ export const users = pgTable(
 );
 
 export const emailOtps = pgTable("email_otps", {
-  id: uuid("id").primaryKey().defaultRandom(),
+  id: uuid("id")
+    .primaryKey()
+    .default(sql`uuid_generate_v7()`),
   emailHash: varchar("email_hash", { length: 64 }).notNull(),
   otpHash: varchar("otp_hash", { length: 64 }).notNull(),
   expiresAt: timestamp("expires_at").notNull(),
@@ -96,7 +101,9 @@ export const emailOtps = pgTable("email_otps", {
 export const sessions = pgTable(
   "sessions",
   {
-    id: uuid("id").primaryKey().defaultRandom(),
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`uuid_generate_v7()`),
     userId: uuid("user_id")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
@@ -109,7 +116,9 @@ export const sessions = pgTable(
 export const templates = pgTable(
   "templates",
   {
-    id: uuid("id").primaryKey().defaultRandom(),
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`uuid_generate_v7()`),
     slug: varchar("slug", { length: 255 }).notNull().unique(),
     title: varchar("title", { length: 200 }).notNull(),
     description: varchar("description", { length: 200 }),
@@ -139,7 +148,9 @@ export const templates = pgTable(
 export const templateFlags = pgTable(
   "template_flags",
   {
-    id: uuid("id").primaryKey().defaultRandom(),
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`uuid_generate_v7()`),
     templateId: uuid("template_id")
       .notNull()
       .references(() => templates.id, { onDelete: "cascade" }),
@@ -152,7 +163,9 @@ export const templateFlags = pgTable(
 );
 
 export const moderationLog = pgTable("moderation_log", {
-  id: uuid("id").primaryKey().defaultRandom(),
+  id: uuid("id")
+    .primaryKey()
+    .default(sql`uuid_generate_v7()`),
   templateId: uuid("template_id")
     .notNull()
     .references(() => templates.id, { onDelete: "cascade" }),
@@ -190,7 +203,9 @@ export const dataSourceMeta = pgTable("data_source_meta", {
 export const issueTags = pgTable(
   "issue_tags",
   {
-    id: uuid("id").primaryKey().defaultRandom(),
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`uuid_generate_v7()`),
     name: varchar("name", { length: 50 }).notNull().unique(),
     suggestedBy: uuid("suggested_by").references(() => users.id, { onDelete: "set null" }),
     status: varchar("status", { length: 20 }).notNull().default("pending"),
@@ -225,7 +240,9 @@ export const templateIssueTags = pgTable(
 export const votes = pgTable(
   "votes",
   {
-    id: uuid("id").primaryKey().defaultRandom(),
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`uuid_generate_v7()`),
     rollCall: integer("roll_call").notNull(),
     chamber: varchar("chamber", { length: 10 }).$type<Chamber>().notNull(),
     congress: integer("congress").notNull(),
@@ -280,7 +297,9 @@ export const memberVotes = pgTable(
 export const bills = pgTable(
   "bills",
   {
-    id: uuid("id").primaryKey().defaultRandom(),
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`uuid_generate_v7()`),
     billNumber: varchar("bill_number", { length: 50 }).notNull(),
     billType: varchar("bill_type", { length: 10 }).$type<BillType>().notNull(),
     congress: integer("congress").notNull(),
@@ -313,7 +332,9 @@ export const bills = pgTable(
 export const amendments = pgTable(
   "amendments",
   {
-    id: uuid("id").primaryKey().defaultRandom(),
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`uuid_generate_v7()`),
     amendmentNumber: varchar("amendment_number", { length: 20 }).notNull(),
     amendmentType: varchar("amendment_type", { length: 10 }).$type<AmendmentType>().notNull(),
     congress: integer("congress").notNull(),
@@ -345,7 +366,9 @@ export const amendments = pgTable(
 export const templateUses = pgTable(
   "template_uses",
   {
-    id: uuid("id").primaryKey().defaultRandom(),
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`uuid_generate_v7()`),
     templateId: uuid("template_id")
       .notNull()
       .references(() => templates.id, { onDelete: "cascade" }),

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,6 @@
 import { defineMiddleware } from "astro:middleware";
 import { eq, and, gt } from "drizzle-orm";
+import { uuidv7 } from "uuidv7";
 import { createDb } from "./db/client";
 import { sessions } from "./db/schema";
 import { getConfig } from "./lib/config";
@@ -58,7 +59,7 @@ export const onRequest = defineMiddleware(async ({ cookies, locals, request }, n
     }
 
     if (!visitorId) {
-      visitorId = crypto.randomUUID();
+      visitorId = uuidv7();
       const sig = await hmacSign(visitorId, hmacKey);
       cookies.set("visitor_id", `${visitorId}.${sig}`, {
         path: "/",
@@ -70,7 +71,7 @@ export const onRequest = defineMiddleware(async ({ cookies, locals, request }, n
 
     locals.visitorId = visitorId;
   } else {
-    locals.visitorId = crypto.randomUUID();
+    locals.visitorId = uuidv7();
   }
 
   const sessionId = cookies.get("session")?.value;


### PR DESCRIPTION
## Summary

- Adds migration `0015_swap-v4-to-v7-ids.sql` that completes the UUID v7 swap across all 11 UUID-keyed tables: drops FK/PK constraints, remaps all 18 FK references through `v7_id` columns, copies v7 values into `id`, restores all constraints, and drops the temporary `v7_id` columns
- Updates all 11 schema defaults from `.defaultRandom()` to `.default(sql`uuid_generate_v7()`)` 
- Replaces `crypto.randomUUID()` with `uuidv7()` in middleware for visitor ID generation

**Known side effect:** All active sessions are invalidated (session IDs changed). Users will need to re-authenticate.

## Test plan

- [x] Migration ran successfully on dev branch (`br-winter-recipe-afwrwb8w`)
- [x] Verified `v7_id` columns are dropped from all tables
- [x] Verified all 15 FK constraints restored with correct ON DELETE rules
- [x] Verified all PKs restored (11 single-column + 3 composite)
- [x] Confirmed IDs are v7 format (time-ordered `019c...` prefix)
- [x] Confirmed FK integrity via JOIN queries
- [x] Confirmed new default generates v7 UUIDs (`INSERT ... RETURNING id`)
- [x] `pnpm lint && pnpm format:check && pnpm typecheck` all pass
- [x] `pnpm test` — 981/981 tests pass (80 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)